### PR TITLE
BL-5898 - Make DVSA not be a header

### DIFF
--- a/templates/email/OneDayAfterNotificationEmail.txt
+++ b/templates/email/OneDayAfterNotificationEmail.txt
@@ -10,7 +10,7 @@ It’s illegal to drive without a valid MOT - you can be fined up to £1000.
 
 Book in now at an approved MOT test centre. Find out about getting your MOT at https://www.gov.uk/getting-an-mot
 
-#DVSA (Driver and Vehicle Standards Agency)
+DVSA (Driver and Vehicle Standards Agency)
 
-Unsubscribe from MOT reminders: 
+Unsubscribe from MOT reminders:
 ((unsubscribe_link))

--- a/templates/email/OneMonthNotificationEmail.txt
+++ b/templates/email/OneMonthNotificationEmail.txt
@@ -14,7 +14,7 @@ You can get a vehicle MOT tested up to a month (minus a day) before its ((due_or
 
 Check if a vehicle or part has been recalled because of a safety fault at https://www.gov.uk/check-if-a-vehicle-has-been-recalled
 
-#DVSA (Driver and Vehicle Standards Agency)
+DVSA (Driver and Vehicle Standards Agency)
 
-Unsubscribe from MOT reminders: 
+Unsubscribe from MOT reminders:
 ((unsubscribe_link))

--- a/templates/email/SignUpConfirmEmail.txt
+++ b/templates/email/SignUpConfirmEmail.txt
@@ -8,4 +8,4 @@ Click to activate your MOT reminder:
 
 ((confirmation_link))
 
-#DVSA (Driver and Vehicle Standards Agency)
+DVSA (Driver and Vehicle Standards Agency)

--- a/templates/email/TwoWeekNotificationEmail.txt
+++ b/templates/email/TwoWeekNotificationEmail.txt
@@ -8,7 +8,7 @@ MESSAGE CONTENT
 
 Book in for a test now at an approved MOT test centre. Find out about getting your MOT at https://www.gov.uk/getting-an-mot
 
-#DVSA (Driver and Vehicle Standards Agency)
+DVSA (Driver and Vehicle Standards Agency)
 
-Unsubscribe from MOT reminders: 
+Unsubscribe from MOT reminders:
 ((unsubscribe_link))


### PR DESCRIPTION
Users who use screen readers were finding this confusing. This makes the line beginning 'DVSA' in all the email templates be in a normal font weight.